### PR TITLE
Add ast argument

### DIFF
--- a/src/astuse.ts
+++ b/src/astuse.ts
@@ -1,11 +1,11 @@
 import { getSubDir } from "./utils/getSubDir";
 import { getAllFiles } from "./utils/getAllFiles";
-import {analyzetsAst} from "./utils/analyzetsAst";
+import {analyzeAst} from "./utils/analyzeAst";
 import { useAst, useAstSample } from "./utils/useAst";
 
 (async () => {
-    //const startDirectory: string = "../reposv7.0.0failure";
     const startDirectory: string = "../reposv7.0.0failure";
+    //const startDirectory: string = "../reposgv7failure";
     let n: number = 0;
     try {
         const libName: string  = process.argv[2];

--- a/src/utils/analyzeAst.ts
+++ b/src/utils/analyzeAst.ts
@@ -4,7 +4,7 @@ import traverse from "@babel/traverse";
 import { funcNameIdentifiers } from "./funcNameIdentifiers";
 import * as t from "@babel/types";
 
-export const analyzetsAst = async(filePath:string,libName:string,funcName:string): Promise<string[][]> => {
+export const analyzeAst = async(filePath:string,funcName:string): Promise<string[][]> => {
     let resultArray:string[][]=[];
     try {
         let codes: string[] = [];
@@ -64,7 +64,7 @@ export const analyzetsAst = async(filePath:string,libName:string,funcName:string
     return resultArray;
 }
 //機能名を返す
-export const analyzetsAstFuncName = async(filePath:string,libName:string): Promise<string[]> => {
+export const analyzeAstFuncName = async(filePath:string,libName:string): Promise<string[]> => {
     let resultArray:string[]=[];
         try {
             let codes: string[] = [];

--- a/src/utils/getArgAst.ts
+++ b/src/utils/getArgAst.ts
@@ -1,0 +1,69 @@
+const parser = require("@babel/parser");
+import { promises as fsPromises } from 'fs';
+import traverse from "@babel/traverse"; 
+import * as t from "@babel/types";
+//引数追跡　１段階
+export const getAstArg = async(filePath:string,funcName:string): Promise<string[][]> => {
+    let resultArray:string[][]=[];
+    try {
+        let codes: string[] = [];
+        //ファイルの内容を取得
+        if (filePath.endsWith('.js') || filePath.endsWith('.ts')) {
+            const fileContent: string = await fsPromises.readFile(filePath, 'utf8');
+            const parsed = parser.parse(fileContent, {sourceType: 'unambiguous', plugins: ["typescript",'decorators-legacy']});
+            //const parsed = parser.parse(fileContent, { ecmaVersion: 2020, sourceType: 'script', plugins: ["typescript"] });
+            traverse(parsed, {
+                VariableDeclarator(path: any) {
+                    const node = path.node;
+                    const declarationNode = path.findParent((p: any) => t.isVariableDeclaration(p.node));
+                    if (t.isIdentifier(node.init?.callee) && node.init.callee.name === '_interopRequireDefault') {
+                        const init = node.init;
+                        if (init.arguments && init.arguments.some((arg: t.Expression | t.Identifier) => t.isIdentifier(arg) && arg.name.includes(funcName))) {
+                            const code: string = fileContent.substring(declarationNode.node.start, declarationNode.node.end);
+                            console.log('code1:'+code);
+                            codes.push(code);
+                        }
+                    } else if (t.isMemberExpression(node.init) && node.init.property.name === 'default') {
+                        //.default対応
+                        const code = fileContent.substring(declarationNode.node.start, declarationNode.node.end);;
+                        codes.push(code);
+                    }
+                },
+                CallExpression(path: any) {
+                    const node = path.node;
+                    // 関数の呼び出しを見つける
+                    if (node.callee.type === 'Identifier' && node.callee.name.includes(funcName)) {
+                        if (node.arguments.length > 0) {
+                            const code = fileContent.substring(node.arguments[0].start, node.arguments[node.arguments.length - 1].end);
+                            codes.push(code);
+                        }
+                    } else if (node.callee.type === 'MemberExpression') {
+                        if (node.callee.object?.type === 'Identifier' && node.callee.object.name.includes(funcName)) {
+                            if (node.arguments.length > 0) {
+                                const code = fileContent.substring(node.arguments[0].start, node.arguments[node.arguments.length - 1].end);
+                                codes.push(code);
+                            }
+                        } else if (node.callee.object && node.callee.object.type === 'MemberExpression') {
+                            // ~~.default.~~()の取得
+                            if (node.callee.object.object && node.callee.object.object.type === 'Identifier') {
+                                if (node.callee.object.object.name.includes(funcName)) {
+                                    if (node.arguments.length > 0) {
+                                        const code = fileContent.substring(node.arguments[0].start, node.arguments[node.arguments.length - 1].end);
+                                        codes.push(code);
+                                    }
+                                }
+                            }
+                        }
+                    }
+                },
+            });
+        }
+        if(codes.length > 0){
+            resultArray.push(codes);
+        }
+    } catch (error) {
+        console.log(`Failed to create AST for file: ${filePath}`);
+        //console.log(error);
+    }
+    return resultArray;
+}

--- a/src/utils/useAst.ts
+++ b/src/utils/useAst.ts
@@ -2,7 +2,7 @@ import fsPromises from 'fs/promises';
 import { funcNameIdentifiers, secfuncNameIdentifiers } from "./funcNameIdentifiers";
 import { extractImportLines } from "./extractImportLines";
 import { analyzeFile } from "./analyzeFile";
-import { analyzetsAst } from "./analyzetsAst";
+import { analyzeAst } from "./analyzeAst";
 
 export const useAst = async (allFiles: string[], libName: string): Promise<string[][]> =>{
     const pattern: string[][] = [];
@@ -20,7 +20,7 @@ export const useAst = async (allFiles: string[], libName: string): Promise<strin
                 let funcName:string[] = funcNameIdentifiers(line, libName);
                 if (funcName.length > 0) {
                     for(const one of funcName){
-                        analyzetsAst(fileContent,libName,one);
+                        analyzeAst(fileContent,one);
                     }
                 }
             }
@@ -42,7 +42,7 @@ export const useAstSample = async (allFiles: string[], libName: string): Promise
         try {
             const fileContent = await fsPromises.readFile(filePath, 'utf8');
             const lines = extractImportLines(fileContent,libName);
-            //const lines = await analyzetsAstFuncName(filePath,libName);
+            //const lines = await analyzeAstFuncName(filePath,libName);
             if(lines.length>0){
                 pattern.push(lines);
             }
@@ -64,7 +64,7 @@ export const useAstSample = async (allFiles: string[], libName: string): Promise
                 //重複を削除
                 const uniquefuncName: string[] = [...new Set(funcName)];
                 for(const one of uniquefuncName){
-                    let result = await analyzetsAst(filePath, libName, one);
+                    let result = await analyzeAst(filePath,one);
                     if (result.length > 0) {
                         //console.log('result:'+result);
                         //.mockImplementationの対策


### PR DESCRIPTION
未使用だったast関連の関数の引数を削除
tsとjsを対象とするため analyzetsAstからanalyzeAstにファイル名を変更

getArgAstという関数名で引数を関数使用部分から取得できる機能を実装
引数ごとにみる場合には，仕様を変更する必要あり